### PR TITLE
Use "test x = y" instead of == in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,18 +62,18 @@ AC_HELP_STRING([--enable-native],
 
 AX_CHECK_COMPILE_FLAG([-O3], [CFLAGS=-O3])
 dnl Not all architectures support -march=native
-if test $enable_native == "yes"; then
+if test $enable_native = "yes"; then
   AX_CHECK_COMPILE_FLAG([-march=native], [], [enable_native=no])
 fi
 
-if test $enable_fat == "yes"; then
+if test $enable_fat = "yes"; then
   dnl Fat build needs compiler who knows all the possible instruction sets
   AX_CHECK_COMPILE_FLAG([-msse2],   [], AC_MSG_ERROR([Compiler does not know -msse2.]))
   AX_CHECK_COMPILE_FLAG([-mssse3],  [], AC_MSG_ERROR([Compiler does not know -mssse3.]))
   AX_CHECK_COMPILE_FLAG([-msse4.1], [], AC_MSG_ERROR([Compiler does not know -msse4.1.]))
   AX_CHECK_COMPILE_FLAG([-mavx],    [], AC_MSG_ERROR([Compiler does not know -mavx.]))
   AX_CHECK_COMPILE_FLAG([-mxop],    [], AC_MSG_ERROR([Compiler does not know -mxop.]))
-elif test $enable_native == "yes"; then
+elif test $enable_native = "yes"; then
   AX_EXT
   CFLAGS="${CFLAGS} -march=native ${SIMD_FLAGS}"
 fi


### PR DESCRIPTION
The ==  form is non-portable and not supported everywhere. Here is the explanation for this issue from pkgsrc:

The "test" command, as well as the "[" command, are not required to know                                                            
the "==" operator. Only a few implementations like bash and some
versions of ksh support it.

When you run "test foo == foo" on a platform that does not support the                                                              
"==" operator, the result will be "false" instead of "true". This can                                                               
lead to unexpected behavior.

There are two ways to fix this error message. If the file that contains                                                             
the "test ==" is needed for building the package, you should create a                                                               
patch for it, replacing the "==" operator with "=". If the file is not                                                              
needed, add its name to the CHECK_PORTABILITY_SKIP variable in the                                                                  
package Makefile.